### PR TITLE
security: bump brace-expansion to 1.1.18 (ReDoS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3441,9 +3441,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "overrides": {
     "ws": "^8.21.0",
     "postcss": "$postcss",
-    "sharp": "$sharp"
+    "sharp": "$sharp",
+    "brace-expansion@1": "^1.1.18"
   }
 }


### PR DESCRIPTION
Resolves two HIGH Dependabot alerts on `brace-expansion` (ReDoS):
- GHSA-rgw5-rvv9-x895 (fixed 1.1.18)
- GHSA-mh99-v99m-4gvg (fixed 1.1.17)

The vulnerable install was `node_modules/brace-expansion@1.1.16` (transitive via root `minimatch`). Pinned the 1.x line to `^1.1.18` with a scoped `brace-expansion@1` override; the unrelated `brace-expansion@5.0.7` install is untouched. Lockfile regenerated - only the affected node changed (version/resolved/integrity).