### PR TITLE
Add founder credit + link to aaronjmars.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,7 @@ pages/
     ├── ActionFC.js   # Farcaster action component
     └── ...
 ```
+
+---
+
+Built by [Aaron Elijah Mars](https://aaronjmars.com), founder of Aeon and MiroShark · [@aaronjmars](https://github.com/aaronjmars)


### PR DESCRIPTION
Adds a footer credit linking back to the personal hub, so the profile <-> project link is reciprocal (what makes a sameAs edge count).

One line appended to the README; no other change.